### PR TITLE
Change pypi publish workflow to run on push

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,8 +1,8 @@
 name: pypi-publish
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [ main, master ]
 
 permissions:
   id-token: write


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update the PyPI publish workflow to run on push to `main` and `master` branches instead of on release publication.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf398ec1-7325-4f65-9cf7-c4847fc4794e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf398ec1-7325-4f65-9cf7-c4847fc4794e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

