### PR TITLE
Automate pypi version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,13 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+tag_name = v{new_version}
+
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:src/argorator/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -2,7 +2,8 @@ name: pypi-publish
 
 on:
   push:
-    branches: [ main, master ]
+    tags:
+      - 'v*'
 
 permissions:
   id-token: write

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,0 +1,40 @@
+name: release-bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      part:
+        description: "Version part to bump (patch, minor, major)"
+        required: true
+        default: "patch"
+        type: choice
+        options: [patch, minor, major]
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install bump2version
+        run: |
+          python -m pip install --upgrade pip
+          pip install bump2version
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Bump version
+        run: |
+          bump2version --allow-dirty ${{ github.event.inputs.part }}
+      - name: Push changes and tags
+        run: |
+          git push --follow-tags


### PR DESCRIPTION
Automate version bumping and PyPI releases by introducing a `bump2version` configuration and a GitHub Actions workflow to manage version increments and trigger publishing on tags.

The new `release-bump.yml` workflow allows maintainers to manually trigger a patch, minor, or major version bump, which then creates a commit and a `vX.Y.Z` tag. The existing `pypi-publish.yml` workflow has been updated to listen for these `v*` tags, ensuring that a new PyPI package is automatically published upon a versioned release.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed06db55-9376-46a3-902e-0e4c3900ecd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed06db55-9376-46a3-902e-0e4c3900ecd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

