### PR TITLE
Skip pypi publish for unchanged versions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,11 +17,52 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      
+      - name: Extract version from pyproject.toml
+        id: get-version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $VERSION"
+      
+      - name: Check if version exists on PyPI
+        id: check-pypi
+        run: |
+          python -m pip install --upgrade pip requests
+          
+          # Check if package version exists on PyPI
+          PACKAGE_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['name'])")
+          VERSION="${{ steps.get-version.outputs.VERSION }}"
+          
+          python -c "
+          import requests
+          import sys
+          
+          package = '$PACKAGE_NAME'
+          version = '$VERSION'
+          
+          try:
+              response = requests.get(f'https://pypi.org/pypi/{package}/{version}/json')
+              if response.status_code == 200:
+                  print(f'Version {version} already exists on PyPI')
+                  sys.exit(0)
+              else:
+                  print(f'Version {version} does not exist on PyPI, proceeding with publish')
+                  sys.exit(1)
+          except Exception as e:
+              print(f'Error checking PyPI: {e}')
+              print(f'Assuming version {version} does not exist, proceeding with publish')
+              sys.exit(1)
+          " || echo "SHOULD_PUBLISH=true" >> $GITHUB_OUTPUT
+      
       - name: Build wheel and sdist
+        if: steps.check-pypi.outputs.SHOULD_PUBLISH == 'true'
         run: |
           python -m pip install --upgrade pip build
           python -m build
+      
       - name: Publish to PyPI via Trusted Publisher
+        if: steps.check-pypi.outputs.SHOULD_PUBLISH == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true


### PR DESCRIPTION
Skip PyPI publish workflow if the package version already exists on PyPI.

---
<a href="https://cursor.com/background-agent?bcId=bc-3760dea8-6932-4f8e-9f58-0fe111c9485a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3760dea8-6932-4f8e-9f58-0fe111c9485a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

