### PR TITLE
Update readme examples with default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ echo "✅ Deployment complete!"
 
 ```bash
 $ chmod +x deploy-service.sh
+$ ./deploy-service.sh --help
+usage: deploy-service.sh [-h] --service_name SERVICE_NAME --environment ENVIRONMENT [--version VERSION] [--dry_run DRY_RUN]
+
+options:
+  -h, --help            show this help message and exit
+  --service_name SERVICE_NAME
+  --environment ENVIRONMENT
+  --version VERSION     (default from env: latest)
+  --dry_run DRY_RUN
+
 $ ./deploy-service.sh --service-name api --environment staging --dry-run true
 🚀 Deploying api to staging
 📦 Version: latest
@@ -108,6 +118,15 @@ echo "Custom: $CUSTOM_VAR"
 ```
 
 ```bash
+$ argorator show-env.sh --help
+usage: argorator show-env.sh [-h] --custom_var CUSTOM_VAR [--home HOME] [--user USER]
+
+options:
+  -h, --help            show this help message and exit
+  --custom_var CUSTOM_VAR
+  --home HOME           (default from env: /home/yourusername)
+  --user USER           (default from env: yourusername)
+
 $ argorator show-env.sh --custom-var "test"
 Home: /home/yourusername
 User: yourusername
@@ -126,6 +145,18 @@ echo "Compression: ${COMPRESSION:-gzip}"
 ```
 
 ```bash
+$ argorator backup.sh --help
+usage: argorator backup.sh [-h] [--compression COMPRESSION] ARG1 ARG2
+
+positional arguments:
+  ARG1
+  ARG2
+
+options:
+  -h, --help            show this help message and exit
+  --compression COMPRESSION
+                        (default from env: gzip)
+
 $ argorator backup.sh /data /backups --compression bzip2
 Backing up /data to /backups
 Compression: bzip2


### PR DESCRIPTION
Update README examples to show default values from environment variables in help text.

---
<a href="https://cursor.com/background-agent?bcId=bc-73af048b-60b3-4459-9958-569af496de5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73af048b-60b3-4459-9958-569af496de5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

