### PR TITLE
Add json input support for script arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,34 @@ Processing files:
   - doc3.txt
 ```
 
+## 🧾 JSON Input (new)
+
+You can pass a JSON object instead of CLI flags. Argorator maps JSON keys to the expected arguments.
+
+- Use `--json-input` with an inline JSON object:
+
+```bash
+argorator script.sh --json-input '{"NAME":"Alice","ARG1":"first","ARGS":["r1","r2"]}'
+```
+
+- Or pipe JSON via stdin when no CLI args are provided (except `--help`):
+
+```bash
+echo '{"NAME":"Alice"}' | argorator script.sh
+```
+
+Notes:
+- CLI flags override values from JSON when both are provided
+- Keys matching variable names (case-insensitive) map to `--var value`
+- `ARG<n>` keys map to positionals; `ARGS` maps to additional args (list or scalar)
+- Scripts can opt out of auto-reading JSON from stdin with a directive comment:
+
+```bash
+# argorator: no-json-stdin
+```
+
+Caveat: If your script already reads from stdin, piping JSON to stdin for Argorator will conflict. Use `--json-input` instead.
+
 ## 🛠️ Advanced Usage
 
 ### Compile Mode


### PR DESCRIPTION
Add JSON input support via `--json-input` option and stdin to provide an alternative, structured way to pass arguments to Argorator scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-e13fc444-3b34-4a00-95fe-0b86a06ca6be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e13fc444-3b34-4a00-95fe-0b86a06ca6be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

