### PR TITLE
Fix help discoverability, remove comments, and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-12-26
+
+### Fixed
+- Help system now shows subcommands (`run`, `compile`, `export`) when no arguments are provided
+- Removed "#argorator: injected variable definitions" comment from compiled scripts for cleaner output
+
 ### Changed
 - Updated tagline to "stop writing argument parsing in bash"
 - Added before/after example showing bash argument parsing complexity vs Argorator
@@ -27,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Main landing page with full project overview
   - Organized documentation structure in docs/ folder
   - Google-style annotations feature documentation
-
-### Fixed
 - Tests badge in README now points to correct repository (dotle-git/argorator)
 - PyPI version badge switched to shields.io for better reliability and update frequency
   - Automated deployment via GitHub Actions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "argorator"
-version = "0.3.0"
+version = "0.3.1"
 description = "CLI to wrap shell scripts and expose variables/positionals as argparse options"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Improve CLI help discoverability for subcommands and remove internal comments from compiled scripts.

Previously, `argorator`'s `compile` and `export` subcommands were not listed when running `argorator` or `argorator --help`, making them hard to discover. This PR fixes that by explicitly showing subcommands in the top-level help. It also removes an internal comment (`# argorator: injected variable definitions`) from compiled scripts for cleaner output. The version is also bumped to 0.3.1.

---
<a href="https://cursor.com/background-agent?bcId=bc-21aa7c75-3090-4957-8d3e-21e58ae2b4b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21aa7c75-3090-4957-8d3e-21e58ae2b4b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

