### PR TITLE
Research argorator annotation ideas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Short alias validation and safeguards
+  - Enforce single-character short aliases (e.g., `-v`, `-p`)
+  - Automatically prepend `-` if omitted in annotations
+  - Reject reserved `-h` alias (kept for help)
+
 ### Fixed
 - Set parser program name to the script name instead of "cli.py" in help output
 

--- a/docs/features/google_style_annotations.md
+++ b/docs/features/google_style_annotations.md
@@ -80,6 +80,12 @@ Add short aliases for convenience:
 # script.sh --service api --port 9000 --verbose
 ```
 
+Rules and caveats:
+- Short aliases are single-character options like `-s`, `-p`, `-v`.
+- If you write `[alias: v]`, Argorator normalizes it to `-v`.
+- The `-h` alias is reserved for help and cannot be used.
+- Duplicate short aliases across different variables are rejected.
+
 ### Choice Parameters
 
 ```bash

--- a/src/argorator/cli.py
+++ b/src/argorator/cli.py
@@ -166,6 +166,17 @@ def build_dynamic_arg_parser(
 	
 	parser = ConflictAwareArgumentParser(add_help=True, prog=script_name)
 	
+	# Pre-check for duplicate short aliases across all variables we will add
+	all_names: List[str] = list(undefined_vars) + list(env_vars.keys())
+	alias_to_name: Dict[str, str] = {}
+	for name in all_names:
+		annotation = annotations.get(name)
+		if annotation and annotation.alias:
+			alias = annotation.alias
+			if alias in alias_to_name:
+				raise ValueError(f"duplicate short alias '{alias}' for variables {alias_to_name[alias]} and {name}")
+			alias_to_name[alias] = name
+	
 	# Helper function to get type converter
 	def get_type_converter(type_str: str):
 		if type_str == 'int':

--- a/src/argorator/models.py
+++ b/src/argorator/models.py
@@ -30,11 +30,22 @@ class ArgumentAnnotation(BaseModel):
     @field_validator('alias')
     @classmethod
     def validate_alias(cls, v: Optional[str]) -> Optional[str]:
-        """Validate that alias starts with a single dash."""
-        if v is not None and not v.startswith('-'):
-            # Prepend dash if not present
-            return f'-{v}'
-        return v
+        """Validate short alias formatting and reserved names.
+
+        Rules:
+        - If provided without a dash, prepend a single '-'
+        - Must be exactly a single-dash followed by one non-whitespace character
+        - '-h' is reserved for help and cannot be used
+        """
+        if v is None:
+            return v
+        alias = v if v.startswith('-') else f'-{v}'
+        # Disallow whitespace and multi-character long-style forms
+        if len(alias) != 2 or not alias.startswith('-') or alias[1].isspace():
+            raise ValueError("alias must be a short option like '-v'")
+        if alias == '-h':
+            raise ValueError("alias '-h' is reserved for help")
+        return alias
     
     @field_validator('choices')
     @classmethod

--- a/tests/test_google_annotations.py
+++ b/tests/test_google_annotations.py
@@ -159,6 +159,37 @@ def test_google_annotations_with_argparse():
     assert args.DEBUG is True
 
 
+def test_short_alias_parsing_and_usage():
+    """Short aliases are parsed, normalized, and usable for all types."""
+    annotations = {
+        "SERVICE": ArgumentAnnotation(type="str", help="Service", alias="s"),
+        "PORT": ArgumentAnnotation(type="int", help="Port", default="8080", alias="-p"),
+        "VERBOSE": ArgumentAnnotation(type="bool", help="Verbose", default="false", alias="v"),
+    }
+    parser = cli.build_dynamic_arg_parser(["SERVICE", "PORT", "VERBOSE"], {}, set(), False, annotations)
+    # Use only short options
+    args = parser.parse_args(["-s", "api", "-p", "9001", "-v"])
+    assert args.SERVICE == "api"
+    assert args.PORT == 9001
+    assert args.VERBOSE is True
+
+
+def test_duplicate_short_alias_conflict_raises():
+    """Duplicate short aliases across variables should raise a clear error."""
+    annotations = {
+        "HOST": ArgumentAnnotation(type="str", alias="-p"),
+        "PORT": ArgumentAnnotation(type="int", alias="p"),
+    }
+    with pytest.raises(ValueError):
+        cli.build_dynamic_arg_parser(["HOST", "PORT"], {}, set(), False, annotations)
+
+
+def test_reserved_h_alias_rejected_in_model():
+    """'-h' must be reserved for help and rejected by the model."""
+    with pytest.raises(ValueError):
+        ArgumentAnnotation(type="str", alias="-h")
+
+
 def test_mixed_required_optional():
     """Test mix of required and optional parameters."""
     annotations = {


### PR DESCRIPTION
Add support for short aliases in Argorator annotations, including validation and conflict detection, to improve CLI convenience and robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-40f9a705-9524-4acf-9846-a42278c6a946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40f9a705-9524-4acf-9846-a42278c6a946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

