### PR TITLE
Echo commands with pipe handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `--echo` option to preview what the script would execute without running it
+  - Works with `run` (prints commands while doing no work) and `compile` (prints echo-transformed script)
+  - Special handling for pipes and operators by quoting entire original lines
+
 ### Fixed
 - Set parser program name to the script name instead of "cli.py" in help output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.4.0] - 2025-08-27
+
+### Added
 - New `--echo` option to preview what the script would execute without running it
   - Works with `run` (prints commands while doing no work) and `compile` (prints echo-transformed script)
   - Special handling for pipes and operators by quoting entire original lines

--- a/docs/features/echo_mode.md
+++ b/docs/features/echo_mode.md
@@ -1,0 +1,76 @@
+---
+layout: page
+title: Echo Mode (Dry Run)
+permalink: /docs/features/echo_mode/
+---
+
+# Echo Mode (Dry Run)
+
+Added in Unreleased
+
+Preview what your script would do without executing any commands. Echo mode rewrites each non-comment command line to an `echo "..."` form that prints the exact command line the script would run after variable expansion, while safely neutralizing pipes and operators.
+
+## Why use it?
+
+- Validate variables and positionals resolved by Argorator
+- See the final command lines with values interpolated
+- Avoid side effects in pipelines, redirects, and destructive operations
+
+## Usage
+
+### Run with echo mode
+
+```bash
+argorator run script.sh --echo [script-args]
+
+# Implicit run also works
+argorator script.sh --echo [script-args]
+```
+
+### Compile to echo-transformed script
+
+```bash
+argorator compile script.sh --echo [script-args]
+```
+
+This prints the script with Argorator's injected variable definitions plus every executable line rewritten to `echo "..."`.
+
+## Example
+
+Script:
+
+```bash
+#!/bin/bash
+echo "Building $SERVICE"
+docker build -t "$SERVICE:$TAG" .
+kubectl apply -f manifests.yaml | tee deploy.log
+```
+
+Run in echo mode:
+
+```bash
+argorator run build.sh --service api --tag v1 --echo
+```
+
+Output (representative):
+
+```bash
+echo "echo \"Building $SERVICE\""
+echo "docker build -t \"$SERVICE:$TAG\" ."
+echo "kubectl apply -f manifests.yaml | tee deploy.log"
+```
+
+Note how pipes and operators are quoted inside the echoed string, so no actual pipeline runs.
+
+## Details and behavior
+
+- Shebang is preserved.
+- Argorator's injected variable assignments are preserved so variables expand inside echoed lines.
+- Non-empty, non-comment lines become `echo "..."` with double quotes; backslashes and quotes are escaped.
+- Original script’s own assignments (not injected) are echoed instead of executed.
+- Boolean handling and environment/default resolution are identical to normal mode; only command execution changes.
+
+## Tips
+
+- Use `compile --echo` to inspect the exact transformed script.
+- Use `run --echo` to preview with your current environment and arguments.

--- a/docs/features/echo_mode.md
+++ b/docs/features/echo_mode.md
@@ -6,7 +6,7 @@ permalink: /docs/features/echo_mode/
 
 # Echo Mode (Dry Run)
 
-Added in Unreleased
+Added in 0.4.0
 
 Preview what your script would do without executing any commands. Echo mode rewrites each non-comment command line to an `echo "..."` form that prints the exact command line the script would run after variable expansion, while safely neutralizing pipes and operators.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "argorator"
-version = "0.3.1"
+version = "0.4.0"
 description = "CLI to wrap shell scripts and expose variables/positionals as argparse options"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Add `--echo` option to `run` and `compile` commands to provide a dry-run preview of script execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2adaa04-969b-4d78-8822-8891cdeb0d7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2adaa04-969b-4d78-8822-8891cdeb0d7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

