### PR TITLE
Allow variable overwriting, exclude loop variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Allow overriding top-level defined variables via CLI
+  - Script-assigned variables at top-level are exposed as optional CLI args
+  - Defaults are taken from the script's assigned value
+  - Indented assignments (e.g., inside loops/functions) are ignored
+  - `compile`/`run` replace those assignments with provided values; `export` prints them
+
 ### Fixed
 - Set parser program name to the script name instead of "cli.py" in help output
 


### PR DESCRIPTION
Allow overriding top-level script-defined variables via CLI arguments, using their script values as defaults.

---
<a href="https://cursor.com/background-agent?bcId=bc-eab11142-8d0e-4e89-a029-00bd08302024">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eab11142-8d0e-4e89-a029-00bd08302024">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

