### PR TITLE
Set program name and support description annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Set argument parser program name to script filename without extension for better help display
+- Support for `# Description: ...` annotation to add script description to help output
 
 ### Changed
 

--- a/src/argorator/analyzers.py
+++ b/src/argorator/analyzers.py
@@ -13,8 +13,9 @@ import os
 import re
 from typing import Dict, Optional, Set, Tuple
 
-from .annotations import parse_arg_annotations
+from .annotations import parse_arg_annotations, parse_script_description
 from .contexts import AnalysisContext
+from .models import ScriptMetadata
 from .registry import analyzer
 
 
@@ -171,3 +172,11 @@ def analyze_positional_parameters(context: AnalysisContext) -> None:
 def analyze_annotations(context: AnalysisContext) -> None:
     """Parse comment-based annotations for argument metadata."""
     context.annotations = parse_arg_annotations(context.script_text)
+
+
+@analyzer(order=50)
+def analyze_script_metadata(context: AnalysisContext) -> None:
+    """Parse script-level metadata from comments."""
+    description = parse_script_description(context.script_text)
+    if description:
+        context.script_metadata = ScriptMetadata(description=description)

--- a/src/argorator/annotations.py
+++ b/src/argorator/annotations.py
@@ -1,6 +1,6 @@
 """Parse Google-style annotations from shell script comments."""
 import re
-from typing import Dict
+from typing import Dict, Optional
 
 from .models import ArgumentAnnotation
 
@@ -77,3 +77,30 @@ def parse_arg_annotations(script_text: str) -> Dict[str, ArgumentAnnotation]:
 		annotations[var_name] = ArgumentAnnotation(**annotation_data)
 	
 	return annotations
+
+
+def parse_script_description(script_text: str) -> Optional[str]:
+	"""Parse script description from comments using # Description: format.
+	
+	Looks for comments in the format:
+	- # Description: My script description
+	- #Description: My script description (no space after #)
+	
+	Args:
+		script_text: The full script content
+		
+	Returns:
+		Script description string if found, None otherwise
+	"""
+	# Pattern for script description comment
+	# Matches: # Description: description text
+	pattern = re.compile(
+		r'^\s*#\s*[Dd]escription\s*:\s*(.+?)$',
+		re.MULTILINE | re.IGNORECASE
+	)
+	
+	match = pattern.search(script_text)
+	if match:
+		return match.group(1).strip()
+	
+	return None

--- a/src/argorator/context.py
+++ b/src/argorator/context.py
@@ -81,5 +81,5 @@ class PipelineContext(BaseModel):
         return v
     
     def get_script_name(self) -> Optional[str]:
-        """Get the script name for display purposes."""
-        return self.script_path.name if self.script_path else None
+        """Get the script name for display purposes (without extension)."""
+        return self.script_path.stem if self.script_path else None

--- a/src/argorator/contexts.py
+++ b/src/argorator/contexts.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Set, Any
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator
 
-from .models import ArgumentAnnotation
+from .models import ArgumentAnnotation, ScriptMetadata
 
 
 class BaseContext(BaseModel):
@@ -35,13 +35,14 @@ class AnalysisContext(BaseContext):
     positional_indices: Set[int] = Field(default_factory=set, description="Positional parameter indices used")
     varargs: bool = Field(default=False, description="Whether script uses varargs ($@ or $*)")
     annotations: Dict[str, ArgumentAnnotation] = Field(default_factory=dict, description="Parsed annotations")
+    script_metadata: Optional[ScriptMetadata] = Field(default=None, description="Script-level metadata from comments")
 
     # Temporary data for pipeline steps
     temp_data: Dict[str, Any] = Field(default_factory=dict, description="Temporary data for pipeline steps")
 
     def get_script_name(self) -> Optional[str]:
-        """Get the script name for display purposes."""
-        return self.script_path.name if self.script_path else None
+        """Get the script name for display purposes (without extension)."""
+        return self.script_path.stem if self.script_path else None
 
     @field_validator('positional_indices')
     @classmethod
@@ -62,6 +63,7 @@ class TransformContext(BaseContext):
     positional_indices: Set[int] = Field(default_factory=set, description="Positional parameter indices used")
     varargs: bool = Field(default=False, description="Whether script uses varargs ($@ or $*)")
     annotations: Dict[str, ArgumentAnnotation] = Field(default_factory=dict, description="Parsed annotations")
+    script_metadata: Optional[ScriptMetadata] = Field(default=None, description="Script-level metadata from comments")
     script_path: Optional[Path] = Field(default=None, description="Path to the script file")  # For parser name
 
     # OUTPUTS: What transform produces
@@ -71,8 +73,8 @@ class TransformContext(BaseContext):
     temp_data: Dict[str, Any] = Field(default_factory=dict, description="Temporary data for pipeline steps")
 
     def get_script_name(self) -> Optional[str]:
-        """Get the script name for display purposes."""
-        return self.script_path.name if self.script_path else None
+        """Get the script name for display purposes (without extension)."""
+        return self.script_path.stem if self.script_path else None
 
 
 class ValidateContext(BaseContext):
@@ -146,6 +148,7 @@ def create_transform_context(analysis: AnalysisContext) -> TransformContext:
         positional_indices=analysis.positional_indices,
         varargs=analysis.varargs,
         annotations=analysis.annotations,
+        script_metadata=analysis.script_metadata,
         script_path=analysis.script_path
     )
 

--- a/src/argorator/models.py
+++ b/src/argorator/models.py
@@ -49,3 +49,12 @@ class ArgumentAnnotation(BaseModel):
         # If choices are provided but type is not set, set type to 'choice'
         if self.choices and self.type != 'choice':
             self.type = 'choice'
+
+
+class ScriptMetadata(BaseModel):
+    """Model for script-level metadata."""
+    
+    description: Optional[str] = Field(
+        default=None,
+        description="Script description from # Description: comment"
+    )

--- a/src/argorator/transformers.py
+++ b/src/argorator/transformers.py
@@ -37,7 +37,16 @@ def create_base_parser(context: TransformContext) -> None:
                 help_text = help_text + "\n".join(warning_lines)
             return help_text
     
-    parser = ConflictAwareArgumentParser(add_help=True, prog=context.get_script_name())
+    # Determine description from script metadata
+    description = None
+    if context.script_metadata and context.script_metadata.description:
+        description = context.script_metadata.description
+    
+    parser = ConflictAwareArgumentParser(
+        add_help=True, 
+        prog=context.get_script_name(),
+        description=description
+    )
     context.argument_parser = parser
     
     # Store conflicts for use by other transformers

--- a/tests/test_script_metadata.py
+++ b/tests/test_script_metadata.py
@@ -1,0 +1,249 @@
+import pytest
+from pathlib import Path
+from argorator.annotations import parse_script_description
+from argorator.models import ScriptMetadata
+from argorator.analyzers import analyze_script_metadata
+from argorator.contexts import AnalysisContext
+from argorator.transformers import create_base_parser
+from argorator.pipeline import Pipeline
+
+
+def test_parse_script_description_basic():
+    """Test parsing basic script description."""
+    script = """#!/bin/bash
+# Description: This script does something useful
+echo "Hello World"
+"""
+    description = parse_script_description(script)
+    assert description == "This script does something useful"
+
+
+def test_parse_script_description_case_insensitive():
+    """Test that description parsing is case insensitive."""
+    script = """#!/bin/bash
+# description: This script does something useful
+echo "Hello World"
+"""
+    description = parse_script_description(script)
+    assert description == "This script does something useful"
+
+
+def test_parse_script_description_no_space_after_hash():
+    """Test parsing when there's no space after the hash."""
+    script = """#!/bin/bash
+#Description: This script does something useful
+echo "Hello World"
+"""
+    description = parse_script_description(script)
+    assert description == "This script does something useful"
+
+
+def test_parse_script_description_extra_spaces():
+    """Test parsing with extra spaces around colon."""
+    script = """#!/bin/bash
+# Description   :   This script does something useful
+echo "Hello World"
+"""
+    description = parse_script_description(script)
+    assert description == "This script does something useful"
+
+
+def test_parse_script_description_not_found():
+    """Test when no description is found."""
+    script = """#!/bin/bash
+# Some other comment
+echo "Hello World"
+"""
+    description = parse_script_description(script)
+    assert description is None
+
+
+def test_parse_script_description_multiple_lines():
+    """Test that only the first description is returned."""
+    script = """#!/bin/bash
+# Description: First description
+# Description: Second description
+echo "Hello World"
+"""
+    description = parse_script_description(script)
+    assert description == "First description"
+
+
+def test_script_metadata_model():
+    """Test ScriptMetadata model creation and validation."""
+    metadata = ScriptMetadata(description="Test description")
+    assert metadata.description == "Test description"
+    
+    # Test with None description
+    metadata_none = ScriptMetadata()
+    assert metadata_none.description is None
+
+
+def test_analyze_script_metadata_with_description():
+    """Test the analyze_script_metadata function with a description."""
+    script_text = """#!/bin/bash
+# Description: My awesome script
+echo "Hello World"
+"""
+    context = AnalysisContext(script_text=script_text)
+    
+    analyze_script_metadata(context)
+    
+    assert context.script_metadata is not None
+    assert context.script_metadata.description == "My awesome script"
+
+
+def test_analyze_script_metadata_no_description():
+    """Test the analyze_script_metadata function without a description."""
+    script_text = """#!/bin/bash
+# Some comment
+echo "Hello World"
+"""
+    context = AnalysisContext(script_text=script_text)
+    
+    analyze_script_metadata(context)
+    
+    assert context.script_metadata is None
+
+
+def test_get_script_name_strips_extension():
+    """Test that get_script_name strips file extensions."""
+    script_path = Path("/path/to/my_script.sh")
+    context = AnalysisContext(script_text="", script_path=script_path)
+    
+    assert context.get_script_name() == "my_script"
+
+
+def test_get_script_name_no_extension():
+    """Test get_script_name with files that have no extension."""
+    script_path = Path("/path/to/my_script")
+    context = AnalysisContext(script_text="", script_path=script_path)
+    
+    assert context.get_script_name() == "my_script"
+
+
+def test_get_script_name_multiple_extensions():
+    """Test get_script_name with multiple extensions."""
+    script_path = Path("/path/to/my_script.test.sh")
+    context = AnalysisContext(script_text="", script_path=script_path)
+    
+    # .stem removes only the last extension
+    assert context.get_script_name() == "my_script.test"
+
+
+def test_get_script_name_none_path():
+    """Test get_script_name when script_path is None."""
+    context = AnalysisContext(script_text="")
+    
+    assert context.get_script_name() is None
+
+
+def test_parser_creation_with_description(tmp_path):
+    """Test that ArgumentParser is created with script description."""
+    script_content = """#!/bin/bash
+# Description: This is my test script for validation
+# NAME: User name
+echo "Hello $NAME"
+"""
+    
+    script_path = tmp_path / "test_script.sh"
+    script_path.write_text(script_content)
+    
+    # Create a pipeline and run the analysis and transform stages
+    pipeline = Pipeline()
+    command = pipeline.parse_command_line(["run", str(script_path)])
+    
+    # Run analysis stage
+    analysis = pipeline.create_analysis_context(command)
+    analysis = pipeline.run_analysis_stage(analysis)
+    
+    # Run transform stage  
+    transform = pipeline.run_transform_stage(analysis)
+    
+    # Check that the parser has the correct program name and description
+    assert transform.argument_parser is not None
+    assert transform.argument_parser.prog == "test_script"
+    assert transform.argument_parser.description == "This is my test script for validation"
+
+
+def test_parser_creation_without_description(tmp_path):
+    """Test that ArgumentParser is created without description when none provided."""
+    script_content = """#!/bin/bash
+# NAME: User name
+echo "Hello $NAME"
+"""
+    
+    script_path = tmp_path / "test_script.sh"
+    script_path.write_text(script_content)
+    
+    # Create a pipeline and run the analysis and transform stages
+    pipeline = Pipeline()
+    command = pipeline.parse_command_line(["run", str(script_path)])
+    
+    # Run analysis stage
+    analysis = pipeline.create_analysis_context(command)
+    analysis = pipeline.run_analysis_stage(analysis)
+    
+    # Run transform stage  
+    transform = pipeline.run_transform_stage(analysis)
+    
+    # Check that the parser has the correct program name but no description
+    assert transform.argument_parser is not None
+    assert transform.argument_parser.prog == "test_script"
+    assert transform.argument_parser.description is None
+
+
+def test_help_output_includes_description(tmp_path):
+    """Test that --help output includes the script description."""
+    script_content = """#!/bin/bash
+# Description: A helpful script that greets users
+# NAME: The user's name
+echo "Hello $NAME"
+"""
+    
+    script_path = tmp_path / "greet.sh"
+    script_path.write_text(script_content)
+    
+    # Create a pipeline and try to parse --help
+    pipeline = Pipeline()
+    command = pipeline.parse_command_line(["run", str(script_path)])
+    
+    # Run analysis and transform stages
+    analysis = pipeline.create_analysis_context(command)
+    analysis = pipeline.run_analysis_stage(analysis)
+    transform = pipeline.run_transform_stage(analysis)
+    
+    # Get help text
+    help_text = transform.argument_parser.format_help()
+    
+    # Check that description and program name are in help text
+    assert "greet" in help_text  # program name without extension
+    assert "A helpful script that greets users" in help_text  # description
+
+
+def test_help_output_without_description(tmp_path):
+    """Test that --help output works correctly without a description."""
+    script_content = """#!/bin/bash
+# NAME: The user's name
+echo "Hello $NAME"
+"""
+    
+    script_path = tmp_path / "greet.sh"
+    script_path.write_text(script_content)
+    
+    # Create a pipeline and try to parse --help
+    pipeline = Pipeline()
+    command = pipeline.parse_command_line(["run", str(script_path)])
+    
+    # Run analysis and transform stages
+    analysis = pipeline.create_analysis_context(command)
+    analysis = pipeline.run_analysis_stage(analysis)
+    transform = pipeline.run_transform_stage(analysis)
+    
+    # Get help text
+    help_text = transform.argument_parser.format_help()
+    
+    # Check that program name is in help text but no description
+    assert "greet" in help_text  # program name without extension
+    # Should not contain any mention of description
+    assert "description" not in help_text.lower()


### PR DESCRIPTION
Set argument parser program name to script filename without extension and add support for `# Description: ...` annotation to include script descriptions in help output.

---
Linear Issue: [CLI-31](https://linear.app/cli-test/issue/CLI-31/feature-argument-parser-program-name)

<a href="https://cursor.com/background-agent?bcId=bc-846a5364-8657-49ac-9bbe-b801da9abfc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-846a5364-8657-49ac-9bbe-b801da9abfc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

