### PR TITLE
Fix default value parsing in argument comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed default value parsing in Google-style annotations
+  - Empty default values (e.g., `Default:` or `Default: `) are now properly handled as no default
+  - Descriptions ending with periods (e.g., `# VAR (str): Description.`) are now correctly parsed
+  - Improved regex pattern to prevent cross-line matching issues
+  - Line-by-line processing prevents multiline default value contamination
+
 ## [0.5.2] - 2025-01-28
 
 ### Added


### PR DESCRIPTION
Fix parsing of default values in Google-style argument comments to correctly detect defaults in various edge cases.

The previous regex-based parsing had issues with descriptions ending with a period when no default was present, empty default value declarations (e.g., `Default:`), and incorrectly matching across multiple lines, leading to truncated or contaminated default values. The new approach processes comments line-by-line with more precise regex patterns to address these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-343a88c7-2c39-4589-85db-395f26fd1f27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-343a88c7-2c39-4589-85db-395f26fd1f27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

